### PR TITLE
Changed PDF file name #83

### DIFF
--- a/src/components/DisplayCard.js
+++ b/src/components/DisplayCard.js
@@ -33,7 +33,7 @@ const DisplayCard = ({ data, repositories }) => {
         <div>
           <ReactToPdf
             targetRef={ref}
-            filename="resume_github.pdf"
+            filename = {data.name + "_Github_Resume"}
             options={options}
             scale={0.7}
           >


### PR DESCRIPTION
# Description

Changed the generating PDF file name from resume_github.pdf to Username_Github_Resume.pdf 

Fixes #83 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

I run the project and generated the pdf of my profile resume and the format was as asked by the project admin.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# Screenshot
![githubbbb](https://user-images.githubusercontent.com/59971890/93487014-7a0b8100-f922-11ea-8ad4-ac7c2a0eb32b.png)
