### PR TITLE
Fixed unnecessary white space above profile picture in mobile view

### DIFF
--- a/src/components/DisplayCard.js
+++ b/src/components/DisplayCard.js
@@ -74,7 +74,7 @@ const DisplayCard = ({ data, repositories, langs, orgs }) => {
           <div className="container profile-box" ref={ref} style = { {marginTop: 40}}>
             <div className="row">
               <div className="col-md-4 left-co" >
-                <div className="left-side" style = {{marginTop:160}}>
+                <div className="left-side">
                   <div className="profile-info" >
                     <img
                       src={image}


### PR DESCRIPTION
# Description
There was a big marginTop set above the left region which was making the unnecessary whitespace above the profile picture.

Fixes #89 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Test A
![image](https://user-images.githubusercontent.com/51456744/93924746-c72c9000-fd32-11ea-99e3-5c63a325567e.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
